### PR TITLE
Fix issue #9: Make the background red

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #FF0000;
   --foreground: #171717;
 }
 
@@ -14,7 +14,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #CC0000;
     --foreground: #ededed;
   }
 }


### PR DESCRIPTION
This pull request fixes #9.

The issue requested the global background to be a visually appealing red color. The agent modified `src/app/globals.css` to change the `--background` CSS variable. For the default color scheme, it changed `--background` from `#ffffff` (white) to `#FF0000` (pure red). For the dark color scheme, it changed `--background` from `#0a0a0a` (very dark gray) to `#CC0000` (a slightly darker shade of red). These changes directly address the request to make the global background red by modifying the CSS variables that control the background color.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌