### PR TITLE
Fix issue #9: Make the background red

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #FF6347; /* Tomato Red */
   --foreground: #171717;
 }
 
@@ -14,7 +14,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #CD5C5C; /* Indian Red for dark mode */
     --foreground: #ededed;
   }
 }


### PR DESCRIPTION
This pull request fixes #9.

The issue requested a visually appealing red color for the global background. The agent modified `src/app/globals.css` to change the `--background` CSS variable. In light mode, it set `--background` to `#FF6347` (Tomato Red), and in dark mode, it set `--background` to `#CD5C5C` (Indian Red). Both are shades of red and are applied globally via CSS variables, thus resolving the issue.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌