### PR TITLE
Fix issue #25: Global background red

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #ff0000;
   --foreground: #171717;
 }
 
@@ -14,7 +14,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #cc0000;
     --foreground: #ededed;
   }
 }


### PR DESCRIPTION
This pull request fixes #25.

The agent successfully resolved the issue by changing the `--background` CSS variable to a shade of red (`#ff0000`) for the default color scheme and a slightly darker red (`#cc0000`) for the dark color scheme. This directly addresses the request to make the global background a visually appealing red color.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌