### PR TITLE
Fix issue #32: Global RED background color

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #FF0000;
   --foreground: #171717;
 }
 
@@ -14,7 +14,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #FF0000;
     --foreground: #ededed;
   }
 }


### PR DESCRIPTION
This pull request fixes #32.

The agent successfully modified the `globals.css` file. It changed the `--background` CSS variable in both the default and dark mode `:root` declarations from a light color (`#ffffff` and `#0a0a0a` respectively) to `#FF0000`, which is a pure red color. This directly addresses the request to make the global background a visually appealing red color by setting the background variable to red for both light and dark modes.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌