### PR TITLE
Fix issue #37: make the GLOBAL background color RED

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #FF6344;
   --foreground: #171717;
 }
 
@@ -14,7 +14,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #CD5C5C;
     --foreground: #ededed;
   }
 }


### PR DESCRIPTION
This pull request fixes #37.

The agent modified `src/app/globals.css` to change the `--background` CSS variable. For the default color scheme, it changed `--background` from `#ffffff` (white) to `#FF6344` (Tomato, a shade of red). For the dark color scheme, it changed `--background` from `#0a0a0a` (very dark gray) to `#CD5C5C` (IndianRed, another shade of red). These changes directly address the request to make the global background a visually appealing red color by applying red hues to both light and dark modes.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌