### PR TITLE
Fix issue #37: make the GLOBAL background color RED

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #FF6347;
   --foreground: #171717;
 }
 
@@ -14,7 +14,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #FF6347;
     --foreground: #ededed;
   }
 }


### PR DESCRIPTION
This pull request fixes #37.

The issue requested a visually appealing red color for the global background. The agent modified the `globals.css` file, specifically changing the `--background` CSS variable in both the default and dark mode `:root` declarations. The color was changed from `#ffffff` and `#0a0a0a` respectively to `#FF6347`. This hexadecimal color code corresponds to "Tomato", which is a shade of red and can be considered visually appealing. This directly addresses the request to change the global background to a red color.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌