### PR TITLE
Fix issue #64: add a side bar

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,0 +1,13 @@
+
+> waffle@0.1.0 dev
+> next dev --turbopack -p 53264
+
+   ▲ Next.js 15.3.2 (Turbopack)
+   - Local:        http://localhost:53264
+   - Network:      http://172.17.0.2:53264
+
+ ✓ Starting...
+ ✓ Ready in 931ms
+ ○ Compiling / ...
+ ✓ Compiled / in 2.5s
+ GET / 200 in 2823ms

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,18 +8,11 @@ const Sidebar: React.FC = () => {
         <Image src="/vercel.svg" alt="Vercel Logo" width={100} height={24} />
       </div>
       <nav className="space-y-2">
+        <a href="#" className="block py-2 px-4 rounded hover:bg-gray-700 transition-colors">Home</a>
         <a href="#" className="block py-2 px-4 rounded hover:bg-gray-700 transition-colors">Dashboard</a>
-        <a href="#" className="block py-2 px-4 rounded hover:bg-gray-700 transition-colors">Profile</a>
-        <a href="#" className="block py-2 px-4 rounded hover:bg-gray-700 transition-colors">Settings</a>
-        <a href="#" className="block py-2 px-4 rounded hover:bg-gray-700 transition-colors">Reports</a>
+        <a href="#" className="block py-2 px-4 rounded hover:bg-gray-700 transition-colors">Users</a>
+        <a href="#" className="block py-2 px-4 rounded hover:bg-gray-700 transition-colors">Admin</a>
       </nav>
-      <div className="pt-6 border-t border-gray-700">
-        <p className="text-sm text-gray-400">Quick Links</p>
-        <ul className="mt-2 space-y-1">
-          <li><a href="#" className="block py-1 px-4 rounded hover:bg-gray-700 transition-colors text-sm">Support</a></li>
-          <li><a href="#" className="block py-1 px-4 rounded hover:bg-gray-700 transition-colors text-sm">Documentation</a></li>
-        </ul>
-      </div>
     </aside>
   );
 };


### PR DESCRIPTION
This pull request fixes #64.

The issue requested the addition of a sidebar with specific entries: Home, Dashboard, Users, and Admin. The provided `git patch` shows modifications to `src/components/Sidebar.tsx`. Specifically, the patch adds a "Home" entry, changes "Profile" to "Users", and "Settings" to "Admin". The "Reports" entry and the "Quick Links" section have been removed. The resulting sidebar now contains "Home", "Dashboard", "Users", and "Admin", which directly matches the requirements in the issue description.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌